### PR TITLE
Add three new repos

### DIFF
--- a/otterdog/eclipse-kuksa.jsonnet
+++ b/otterdog/eclipse-kuksa.jsonnet
@@ -120,5 +120,26 @@ orgs.newOrg('eclipse-kuksa') {
         },
       ],
     },
+    orgs.newRepo('kuksa-common') {
+      allow_merge_commit: true,
+      allow_update_branch: false,
+      delete_branch_on_merge: false,
+      dependabot_security_updates_enabled: true,
+      web_commit_signoff_required: false,
+    },
+    orgs.newRepo('kuksa-python-sdk') {
+      allow_merge_commit: true,
+      allow_update_branch: false,
+      delete_branch_on_merge: false,
+      dependabot_security_updates_enabled: true,
+      web_commit_signoff_required: false,
+    },
+    orgs.newRepo('kuksa-android-companion') {
+      allow_merge_commit: true,
+      allow_update_branch: false,
+      delete_branch_on_merge: false,
+      dependabot_security_updates_enabled: true,
+      web_commit_signoff_required: false,
+    },
   ],
 }


### PR DESCRIPTION
No branch protection from start,
will be added later migration is finished and repo content is stable

**kuksa-common**

Intended to contain kuksa data needed by multiple kuksa repositories. Initial ambition is to copy

https://github.com/eclipse/kuksa.val/tree/master/data/vss-core 
https://github.com/eclipse/kuksa.val/tree/master/jwt 
https://github.com/eclipse/kuksa.val/tree/master/kuksa_certificates

**kuksa-python-sdk**

Intended to contain the KUKSA python client & sdk, currently stored in https://github.com/eclipse/kuksa.val/tree/master/kuksa-client

**kuksa-android-companion**

Intended to contain a new example/template app showing how you can access Kuksa Databroker and use VSS signals from an Android App

Shall not be merged until approved by either @SebastianSchildt or @lukasmittag 