### PR TITLE
Add branch protection for kuksa-common and kuksa-python-sdk

### DIFF
--- a/otterdog/eclipse-kuksa.jsonnet
+++ b/otterdog/eclipse-kuksa.jsonnet
@@ -128,6 +128,9 @@ orgs.newOrg('eclipse-kuksa') {
       workflows+: {
         actions_can_approve_pull_request_reviews: false,
       },
+      branch_protection_rules: [
+        kuksa_default_branch_protection_rule('main')
+      ],
     },
     orgs.newRepo('kuksa-python-sdk') {
       allow_merge_commit: true,
@@ -137,7 +140,10 @@ orgs.newOrg('eclipse-kuksa') {
       web_commit_signoff_required: false,
       workflows+: {
         actions_can_approve_pull_request_reviews: false,
-      },      
+      },
+      branch_protection_rules: [
+        kuksa_default_branch_protection_rule('main')
+      ],
     },
     orgs.newRepo('kuksa-android-companion') {
       allow_merge_commit: true,


### PR DESCRIPTION
Now these two repos are mature enough to have branch protection.

I suggest @SebastianSchildt  or @lukasmittag  shall approve before it is merged