### PR TITLE
Add kuksa-can-provider

### DIFF
--- a/otterdog/eclipse-kuksa.jsonnet
+++ b/otterdog/eclipse-kuksa.jsonnet
@@ -191,5 +191,15 @@ orgs.newOrg('eclipse-kuksa') {
         kuksa_default_branch_protection_rule('main')
       ],
     },
+    orgs.newRepo('kuksa-can-provider') {
+      allow_merge_commit: true,
+      allow_update_branch: false,
+      delete_branch_on_merge: false,
+      dependabot_security_updates_enabled: true,
+      web_commit_signoff_required: false,
+      workflows+: {
+        actions_can_approve_pull_request_reviews: false,
+      },
+    },
   ],
 }


### PR DESCRIPTION
kuksa-can-provider intended to be the new home of
https://github.com/eclipse/kuksa.val.feeders/tree/main/dbc2val

Intentionally no branch protection from start.
To be added later when migration has been verified and finished.

To be merged first after approval of @SebastianSchildt or @lukasmittag 