### PR TITLE
Add branch protection to kuksa-can-provider

### DIFF
--- a/otterdog/eclipse-kuksa.jsonnet
+++ b/otterdog/eclipse-kuksa.jsonnet
@@ -200,6 +200,9 @@ orgs.newOrg('eclipse-kuksa') {
       workflows+: {
         actions_can_approve_pull_request_reviews: false,
       },
+      branch_protection_rules: [
+        kuksa_default_branch_protection_rule('main')
+      ],
     },
   ],
 }


### PR DESCRIPTION
Migration of dbcfeeder now complete so we can add branch protection