### PR TITLE
Add dds repo

### DIFF
--- a/otterdog/eclipse-kuksa.jsonnet
+++ b/otterdog/eclipse-kuksa.jsonnet
@@ -204,5 +204,15 @@ orgs.newOrg('eclipse-kuksa') {
         kuksa_default_branch_protection_rule('main')
       ],
     },
+    orgs.newRepo('kuksa-dds-provider') {
+      allow_merge_commit: true,
+      allow_update_branch: false,
+      delete_branch_on_merge: false,
+      dependabot_security_updates_enabled: true,
+      web_commit_signoff_required: false,
+      workflows+: {
+        actions_can_approve_pull_request_reviews: false,
+      },
+    },
   ],
 }


### PR DESCRIPTION
Intended for migration of
https://github.com/eclipse/kuksa.val.feeders/tree/main/dds2val

Not to be merged until approved by @SebastianSchildt or @lukasmittag. Will change it to "ready for review" as soon as some of them has commented that it looks ok

Branch protection intended to be added when migration finished