### PR TITLE
Add kuksa-gps-provider

### DIFF
--- a/otterdog/eclipse-kuksa.jsonnet
+++ b/otterdog/eclipse-kuksa.jsonnet
@@ -214,5 +214,15 @@ orgs.newOrg('eclipse-kuksa') {
         actions_can_approve_pull_request_reviews: false,
       },
     },
+    orgs.newRepo('kuksa-gps-provider') {
+      allow_merge_commit: true,
+      allow_update_branch: false,
+      delete_branch_on_merge: false,
+      dependabot_security_updates_enabled: true,
+      web_commit_signoff_required: false,
+      workflows+: {
+        actions_can_approve_pull_request_reviews: false,
+      },
+    },
   ],
 }


### PR DESCRIPTION
To migrate https://github.com/eclipse/kuksa.val.feeders/tree/main/gps2val. Deliberately no branch protection from start, will be enabled later when migration is finished.

Will be kept in draft state until @SebastianSchildt or @lukasmittag  has approved