### PR TITLE
Add branch protection and two new repos

### DIFF
--- a/otterdog/eclipse-kuksa.jsonnet
+++ b/otterdog/eclipse-kuksa.jsonnet
@@ -213,8 +213,34 @@ orgs.newOrg('eclipse-kuksa') {
       workflows+: {
         actions_can_approve_pull_request_reviews: false,
       },
+      branch_protection_rules: [
+        kuksa_default_branch_protection_rule('main')
+      ],
     },
     orgs.newRepo('kuksa-gps-provider') {
+      allow_merge_commit: true,
+      allow_update_branch: false,
+      delete_branch_on_merge: false,
+      dependabot_security_updates_enabled: true,
+      web_commit_signoff_required: false,
+      workflows+: {
+        actions_can_approve_pull_request_reviews: false,
+      },
+      branch_protection_rules: [
+        kuksa_default_branch_protection_rule('main')
+      ],
+    },
+    orgs.newRepo('kuksa-csv-provider') {
+      allow_merge_commit: true,
+      allow_update_branch: false,
+      delete_branch_on_merge: false,
+      dependabot_security_updates_enabled: true,
+      web_commit_signoff_required: false,
+      workflows+: {
+        actions_can_approve_pull_request_reviews: false,
+      },
+    },
+    orgs.newRepo('kuksa-someip-provider') {
       allow_merge_commit: true,
       allow_update_branch: false,
       delete_branch_on_merge: false,


### PR DESCRIPTION
This commit:
- Adds branch protection to kuksa-dds-provider and kuksa-gps-provider Migration is now finished
- Adds new repo kuksa-csv-provider Intended for migration of code in https://github.com/eclipse/kuksa.val.feeders/tree/main/csv_provider
- Adds new repo kuksa-someip-provider Intended for migration of code in https://github.com/eclipse/kuksa.val.feeders/tree/main/someip2val

Initially no branch protection on the new repositories, to be added when migration is finished

To be merged first after reviewed/approved by @SebastianSchildt or @lukasmittag 