### PR TITLE
Add org readme repo

### DIFF
--- a/otterdog/eclipse-kuksa.jsonnet
+++ b/otterdog/eclipse-kuksa.jsonnet
@@ -259,5 +259,18 @@ orgs.newOrg('eclipse-kuksa') {
         kuksa_default_branch_protection_rule('main')
       ],
     },
+    orgs.newRepo('.github') {
+      allow_merge_commit: true,
+      allow_update_branch: false,
+      delete_branch_on_merge: false,
+      dependabot_security_updates_enabled: true,
+      web_commit_signoff_required: false,
+      workflows+: {
+        actions_can_approve_pull_request_reviews: false,
+      },
+      branch_protection_rules: [
+        kuksa_default_branch_protection_rule('main')
+      ],
+    },
   ],
 }


### PR DESCRIPTION
Adding a .github repo

The intention is to be able to have a README on org level, i.e. so that a readme can be shown if you go to https://github.com/eclipse-kuksa. That could be used to provide a guide to the repos.

Intention is to have something similar to eclipse-velocitas. If you go to https://github.com/eclipse-velocitas you will see a readme.
That readme comes from https://github.com/eclipse-velocitas/.github/blob/main/profile/README.md

Not to be merged until approved by @lukasmittag or @SebastianSchildt.
