### PR TITLE
Add repos for kuksa.val.services migration

### DIFF
--- a/otterdog/eclipse-kuksa.jsonnet
+++ b/otterdog/eclipse-kuksa.jsonnet
@@ -272,5 +272,26 @@ orgs.newOrg('eclipse-kuksa') {
         kuksa_default_branch_protection_rule('main')
       ],
     },
+    orgs.newRepo('kuksa-mock-provider') {
+      allow_merge_commit: true,
+      allow_update_branch: false,
+      delete_branch_on_merge: false,
+      dependabot_security_updates_enabled: true,
+      web_commit_signoff_required: false,
+      workflows+: {
+        actions_can_approve_pull_request_reviews: false,
+      },
+    },
+    orgs.newRepo('kuksa-incubation') {
+      allow_merge_commit: true,
+      allow_update_branch: false,
+      delete_branch_on_merge: false,
+      dependabot_alerts_enabled: false,
+      dependabot_security_updates_enabled: false,
+      web_commit_signoff_required: false,
+      workflows+: {
+        actions_can_approve_pull_request_reviews: false,
+      },
+    },
   ],
 }


### PR DESCRIPTION
Intended for migration of https://github.com/eclipse/kuksa.val.services/

- hvac_service and seat_service to be moved to kuksa-incubation. They are considered as examples and should not be used for production purposes. For kuksa-incubation we intend to not have dependabot alerts or PRs, to minimize maintenance needs.
- mock_service intended to be migrated to kuksa-mock-provider
- integration_test intended to be moved to kuksa-integration-test

Not to be merged until approved by @SebastianSchildt 

FYI: @lukasmittag @mikehaller